### PR TITLE
correct assigment of completeRank

### DIFF
--- a/public/js/collections.js
+++ b/public/js/collections.js
@@ -60,7 +60,7 @@ function renderCollections() {
     const b = data[i - 1];
     if (percentOf(a.totalNFTs - a.burnedNFTs, a.maxMints - a.burnedNFTs) ===
         percentOf(b.totalNFTs - b.burnedNFTs, b.maxMints - b.burnedNFTs)) {
-      b.completeRank = a.completeRank;
+      a.completeRank = b.completeRank;
     }
   }
 


### PR DESCRIPTION
Per [discord message](https://discord.com/channels/843857162552082462/843858987019665439/965306082731917412).

"Ensure that complete-tied ranks share the same rank" doesn't do what it says it's trying to do

Currently it goes through each one, compares A (data[i]) to the one before it B (data[i - 1]), then sets B's rank to A if they're the same
this does:
Compare a (# 1, rank 2) to b (# 0, rank 1), they're the same, b (# 0) gets a (# 1)'s rank of 2
Compare a (# 2, rank 3) to b (# 1, still rank 2), they're the same, b (# 1) gets a (# 2)'s rank of 3

the expected behavior appears to be "a.completeRank = b.completeRank" in line 63
that would do:
Compare a (# 1, rank 2) to b (# 0, rank 1), they're the same, a (# 1) should get b (# 1)'s rank of 1
Compare a (# 2, rank 3) to b (# 1, now rank 1), they're the same, a (# 2) gets b (# 1)'s rank of 1